### PR TITLE
Add support for user based config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 Jcli - Jenkins Command-line Interface
 =====================================
 
-The ultimate Jenkins ClI ;)
+The ultimate Jenkins CLI ;)
 
 Install
 -------
 
-A virtual environment is recommended for development. To install jcli on your system, run the following commands:
+A virtual environment is recommended for development. To install `jcli` on your
+system, run the following commands:
 
     virtualenv .venv
     source .venv/bin/activate
@@ -15,16 +16,18 @@ A virtual environment is recommended for development. To install jcli on your sy
 Setup config
 ------------
 
-jcli is using configuartion file to connect the server.
+`jcli` is using configuration file to connect the server.
 
-It can be setup in one of the following paths:
+It can be setup in one of the following paths, in that order:
 
+    ~/.config/jcli/jcli.ini
+    ~/jcli/jcli.ini
     /etc/jcli/config.ini
     `pwd`/config.ini
 
-or it can passed as an argument.
+or filename can be passed as an argument.
 
-Minimal configuartion is:
+Minimal configuration is:
 
     [jenkins]
     user=<jenkins_user>
@@ -59,7 +62,7 @@ List all views:
 
 Delete view:
 
-    jcli view delete view90 
+    jcli view delete view90
 
 
 Full list of view commands can be found [here](https://github.com/bregman-arie/jcli/tree/master/doc/view.md)

--- a/jcli/config.py
+++ b/jcli/config.py
@@ -19,8 +19,11 @@ import os
 
 from errors import JcliException
 
-DEFAULT_CONF_FILE = '/etc/jcli/config.ini'
-
+DEFAULT_CONF_FILES = [
+    '~/.config/jcli/jcli.ini',
+    '~/jcli.ini',
+    '/etc/jcli/config.ini'
+    ]
 
 def read(conf_file):
     """Returns config parser object.
@@ -35,8 +38,10 @@ def read(conf_file):
     elif conf_file:
         config_file = conf_file
     else:
-        config_file = DEFAULT_CONF_FILE
-
+        for f in DEFAULT_CONF_FILES:
+            if os.path.isfile(os.path.expanduser(f)):
+                config_file = os.path.expanduser(f)
+                break
     config = ConfigParser.ConfigParser()
 
     # Reading the config file


### PR DESCRIPTION
Now it will be able to load ~/.config/jcli/jcli.conf if it exists.