### PR TITLE
Enable piping job names for deletion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+group: edge
+language: python
+python:
+- '2.7'
+- '3.4'
+- '3.5'
+install:
+- pip install -U setuptools pip tox-travis
+- python setup.py bdist bdist_wheel
+# do not attempt setup.py install or develop, is not fully supported by pbr
+# this does not affect distribution as already packged wheels do work well
+script:
+- tox
+after_success:
+- codecov
+branches:
+  only:
+  - master
+  - develop

--- a/jcli/parse.py
+++ b/jcli/parse.py
@@ -14,10 +14,17 @@
 
 import argparse
 import getpass
+import sys
 
 
 def create_job_parser(client_subparsers, parent_parser):
     """Creates job parser"""
+    if not sys.stdin.isatty():
+        default_args = sys.stdin.read().splitlines()
+        default_nargs = '*'  # when pipeing no args are accepted (empty stdin)
+    else:
+        default_args = None
+        default_nargs = '+'  # without piping, no args would generare error
 
     job_parser = client_subparsers.add_parser("job", parents=[parent_parser])
     job_action_subparser = job_parser.add_subparsers(title="action",
@@ -32,12 +39,16 @@ def create_job_parser(client_subparsers, parent_parser):
     # List
     job_list_parser = job_action_subparser.add_parser(
         "list", help="list job(s)", parents=[parent_parser])
-    job_list_parser.add_argument('name', help='job name or part of it',
-                                 nargs='?')
+    job_list_parser.add_argument('name',
+                                 nargs='*',
+                                 default=default_args,
+                                 help='job name or part of it')
     # Delete
     job_delete_parser = job_action_subparser.add_parser(
         "delete", help="delete job", parents=[parent_parser])
-    job_delete_parser.add_argument('name', nargs='*',
+    job_delete_parser.add_argument('name',
+                                   nargs=default_nargs,
+                                   default=default_args,
                                    help='the name of the job(s) to delete')
 
     # Console Output
@@ -52,9 +63,14 @@ def create_job_parser(client_subparsers, parent_parser):
 
     # Build job
     job_build_parser = job_action_subparser.add_parser(
-        "build", help="build job", parents=[parent_parser])
+        "build",
+        help="build job",
+        parents=[parent_parser])
     job_build_parser.add_argument(
-        'name', help='the name of the job to build')
+        'name',
+        help='the name of the job to build',
+        nargs=default_nargs,
+        default=default_args)
     job_build_parser.add_argument(
         '-p', '--parameters', type=str, help='params for parameterized job')
     job_build_parser.add_argument(
@@ -70,14 +86,21 @@ def create_job_parser(client_subparsers, parent_parser):
         'dest_job_name', help='the name of the new job')
     # Disable job
     job_disable_parser = job_action_subparser.add_parser(
-        "disable", help="disable job", parents=[parent_parser])
+        "disable",
+        help="disable job",
+        parents=[parent_parser])
     job_disable_parser.add_argument(
-        'name', help='the name of the job to disable')
+        'name',
+        help='the name of the job to disable',
+        nargs=default_nargs,
+        default=default_args)
     # Enable job
     job_enable_parser = job_action_subparser.add_parser(
         "enable", help="enables job", parents=[parent_parser])
     job_enable_parser.add_argument('name',
-                                   help='the name of the job to enable')
+                                   help='the name of the job to enable',
+                                   nargs=default_nargs,
+                                   default=default_args)
     # Print information on last build
     job_last_build_parser = job_action_subparser.add_parser(
         "last_build", help="Print information on last build",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML
-python-jenkins
+python-jenkins>=0.4.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ name = jcli
 author = Arie Bregman
 author_email = bregman.arie@gmail.com
 summary = Command-line Interface for Jenkins
-version = 0.0.2
 description-file = README.md
 license = Apache License, Version 2.0
 classifier =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,12 @@ minversion = 1.6
 envlist = py34,py35,py27,pep8
 skipsdist = True
 
+[travis]
+python =
+  2.7: py27, pep8
+  3.4: py34
+  3.5: py35
+
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
Also allows you sto specify multiple job names
or to pipe them from stdin.

Fix: #19

Change-Id: I34cc45022d8655ca33b3148232edf550121fcf71
Enables: `jcli job list | jcli job delete`